### PR TITLE
logging fixes for Linux

### DIFF
--- a/Zaimoni.STL/Logging.h
+++ b/Zaimoni.STL/Logging.h
@@ -56,6 +56,8 @@ EXTERN_C void _log(const char* const B, size_t len);		/* Windows GUI crippled (a
 #define LOG_STRING_LITERAL(B) _log(B,sizeof(B)-1)
 
 #ifdef __cplusplus
+#include <concepts>
+
 /* overloadable adapters for C++ and debug-mode code */
 /* all-uppercased because we may use macro wrappers on these */
 MS_NO_RETURN void FATAL(const char* const B) NO_RETURN;
@@ -80,64 +82,46 @@ inline void INC_INFORM(char B) {_inc_inform(&B,1);}
 inline void LOG(char B) {_log(&B,1);}
 
 /* signed integer shorthands */
-void INFORM(intmax_t B);
-void LOG(intmax_t B);
-void INC_INFORM(intmax_t B);
+extern void _INFORM(intmax_t B);
+extern void _LOG(intmax_t B);
+extern void _INC_INFORM(intmax_t B);
+
+template<std::signed_integral T>
+void INFORM(T val) { _INFORM(static_cast<intmax_t>(val)); }
+
+template<std::signed_integral T>
+void LOG(T val) { _INFORM(static_cast<intmax_t>(val)); }
+
+template<std::signed_integral T>
+void INC_INFORM(T val) { _INC_INFORM(static_cast<intmax_t>(val)); }
 
 /* unsigned integer shorthands */
-void INFORM(uintmax_t B);
-void LOG(uintmax_t B);
-void INC_INFORM(uintmax_t B);
+extern void _INFORM(uintmax_t B);
+extern void _LOG(uintmax_t B);
+extern void _INC_INFORM(uintmax_t B);
+
+template<std::unsigned_integral T>
+void INFORM(T val) { _INFORM(static_cast<uintmax_t>(val)); }
+
+template<std::unsigned_integral T>
+void LOG(T val) { _INFORM(static_cast<uintmax_t>(val)); }
+
+template<std::unsigned_integral T>
+void INC_INFORM(T val) { _INC_INFORM(static_cast<uintmax_t>(val)); }
 
 /* long double shorthands */
-void INFORM(long double B);
-void LOG(long double B);
-void INC_INFORM(long double B);
+extern void _INFORM(long double B);
+extern void _LOG(long double B);
+extern void _INC_INFORM(long double B);
 
-#pragma start_copy signed_inform
-inline void INFORM(signed long B) { return INFORM((intmax_t)(B)); }
-inline void LOG(signed long B) { return LOG((intmax_t)(B)); }
-inline void INC_INFORM(signed long B) { return INC_INFORM((intmax_t)(B)); }
-#pragma end_copy
-#pragma for F in int,short,signed char
-#pragma substitute $F for signed long in signed_inform
-inline void INFORM(int B) { return INFORM((intmax_t)(B)); }
-inline void LOG(int B) { return LOG((intmax_t)(B)); }
-inline void INC_INFORM(int B) { return INC_INFORM((intmax_t)(B)); }
-inline void INFORM(short B) { return INFORM((intmax_t)(B)); }
-inline void LOG(short B) { return LOG((intmax_t)(B)); }
-inline void INC_INFORM(short B) { return INC_INFORM((intmax_t)(B)); }
-inline void INFORM(signed char B) { return INFORM((intmax_t)(B)); }
-inline void LOG(signed char B) { return LOG((intmax_t)(B)); }
-inline void INC_INFORM(signed char B) { return INC_INFORM((intmax_t)(B)); }
-#pragma end_substitute
-#pragma done
+template<std::floating_point T>
+void INFORM(T val) { _INFORM(static_cast<long double>(val)); }
 
-#pragma start_copy unsigned_inform
-inline void INFORM(unsigned long B) {return INFORM((uintmax_t)(B));}
-inline void LOG(unsigned long B) {return LOG((uintmax_t)(B));}
-inline void INC_INFORM(unsigned long B) {return INC_INFORM((uintmax_t)(B));}
-#pragma end_copy
-#pragma for F in unsigned int,unsigned short,unsigned char
-#pragma substitute $F for unsigned long in unsigned_inform
-inline void INFORM(unsigned int B) {return INFORM((uintmax_t)(B));}
-inline void LOG(unsigned int B) {return LOG((uintmax_t)(B));}
-inline void INC_INFORM(unsigned int B) {return INC_INFORM((uintmax_t)(B));}
-inline void INFORM(unsigned short B) {return INFORM((uintmax_t)(B));}
-inline void LOG(unsigned short B) {return LOG((uintmax_t)(B));}
-inline void INC_INFORM(unsigned short B) {return INC_INFORM((uintmax_t)(B));}
-inline void INFORM(unsigned char B) {return INFORM((uintmax_t)(B));}
-inline void LOG(unsigned char B) {return LOG((uintmax_t)(B));}
-inline void INC_INFORM(unsigned char B) {return INC_INFORM((uintmax_t)(B));}
-#pragma end_substitute
-#pragma done
+template<std::floating_point T>
+void LOG(T val) { _INFORM(static_cast<long double>(val)); }
 
-inline void INFORM(double B) { return INFORM((long double)(B)); }
-inline void LOG(double B) { return LOG((long double)(B)); }
-inline void INC_INFORM(double B) { return INC_INFORM((long double)(B)); }
-inline void INFORM(float B) { return INFORM((long double)(B)); }
-inline void LOG(float B) { return LOG((long double)(B)); }
-inline void INC_INFORM(float B) { return INC_INFORM((long double)(B)); }
+template<std::floating_point T>
+void INC_INFORM(T val) { _INC_INFORM(static_cast<long double>(val)); }
 
 #else	/* !defined(__cplusplus) */
 #ifdef NDEBUG

--- a/Zaimoni.STL/OS/log_adapter_inc_inform.cpp
+++ b/Zaimoni.STL/OS/log_adapter_inc_inform.cpp
@@ -9,24 +9,23 @@
 #include <stdio.h>
 
 // intmax_t
-void INC_INFORM(intmax_t B) {
+void _INC_INFORM(intmax_t B) {
 	char buf[sizeof(intmax_t)*CHAR_BIT/3+2];
 	z_imaxtoa(B,buf,10);
 	_inc_inform(buf,strlen(buf));
 }
 
 // uintmax_t
-void INC_INFORM(uintmax_t B) {
+void _INC_INFORM(uintmax_t B) {
 	char buf[sizeof(uintmax_t)*CHAR_BIT/3+2];
 	z_umaxtoa(B,buf,10);
 	_inc_inform(buf,strlen(buf));
 }
 
 // long double
-void INC_INFORM(long double B) {
+void _INC_INFORM(long double B) {
 	char buf[25];
 	sprintf(buf,"%.16Lg",B);
 //	_gcvt(B,10,buf);
 	_inc_inform(buf,strlen(buf));
 }
-

--- a/Zaimoni.STL/OS/log_adapter_inform.cpp
+++ b/Zaimoni.STL/OS/log_adapter_inform.cpp
@@ -9,24 +9,23 @@
 #include <stdio.h>
 
 // intmax_t
-void INFORM(intmax_t B) {
+void _INFORM(intmax_t B) {
 	char buf[sizeof(intmax_t)*CHAR_BIT/3+2];
 	z_imaxtoa(B,buf,10);
 	_inform(buf,strlen(buf));
 }
 
 // uintmax_t
-void INFORM(uintmax_t B) {
+void _INFORM(uintmax_t B) {
 	char buf[sizeof(uintmax_t)*CHAR_BIT/3+2];
 	z_umaxtoa(B,buf,10);
 	_inform(buf,strlen(buf));
 }
 
 // long double
-void INFORM(long double B) {
+void _INFORM(long double B) {
 	char buf[25];
 	sprintf(buf,"%.16Lg",B);
 //	_gcvt(B,10,buf);
 	_inform(buf,strlen(buf));
 }
-

--- a/Zaimoni.STL/OS/log_adapter_log.cpp
+++ b/Zaimoni.STL/OS/log_adapter_log.cpp
@@ -9,24 +9,23 @@
 #include <stdio.h>
 
 // intmax_t
-void LOG(intmax_t B) {
+void _LOG(intmax_t B) {
 	char buf[sizeof(intmax_t)*CHAR_BIT/3+2];
 	z_imaxtoa(B,buf,10);
 	_log(buf,strlen(buf));
 }
 
 // uintmax_t
-void LOG(uintmax_t B) {
+void _LOG(uintmax_t B) {
 	char buf[sizeof(uintmax_t)*CHAR_BIT/3+2];
 	z_umaxtoa(B,buf,10);
 	_log(buf,strlen(buf));
 }
 
 // long double
-void LOG(long double B) {
+void _LOG(long double B) {
 	char buf[25];
 	sprintf(buf,"%.16Lg",B);
 //	_gcvt(B,10,buf);
 	_log(buf,strlen(buf));
 }
-


### PR DESCRIPTION
replaces MSVC specific pragmas with C++20 concept templates
also works around issues with type size differences causing overload conflicts
(mainly that long is 4 bytes on Windows, 8 bytes on 64-bit Linux)

diffs failed for OS/log_adapter_* files because I stripped trailing spaces & changed new line encoding during edits - only thing that changed for those files are function renames (prefix underscore for all the function names).
