### PR TITLE
Linux compile fix for NO_RETURN macro

### DIFF
--- a/Zaimoni.STL/Compiler.h
+++ b/Zaimoni.STL/Compiler.h
@@ -149,44 +149,35 @@
    PURE_C_FUNC: no effects except return value, return value depends only on parameters and global variables
    PTR_RESTRICT: C99 restrict semantics (pointer may be assumed not to be aliased) */
 #define NO_RETURN
-#define MS_NO_RETURN
 #define CONST_C_FUNC
 #define PURE_C_FUNC
 #define ALL_PTR_NONNULL
 #define PTR_NONNULL(A)
 #define PTR_RESTRICT
 
-/* GCC */
 #ifdef __GNUC__
-#define THROW_COMPETENT 1
-#undef NO_RETURN
-#undef CONST_C_FUNC
-#undef PURE_C_FUNC
-#undef ALL_PTR_NONNULL
-#undef PTR_NONNULL
-#undef PTR_RESTRICT
-#define CONST_C_FUNC __attribute__ ((const))
-#define PURE_C_FUNC __attribute__ ((pure))
-#define ALL_PTR_NONNULL __attribute__ ((nonnull))
-#define PTR_NONNULL(A) __attribute__ ((nonnull A))
-#define PTR_RESTRICT __restrict__
+#	define THROW_COMPETENT 1
+#	undef NO_RETURN
+#	define NO_RETURN __attribute__((noreturn))
+#	undef CONST_C_FUNC
+#	define CONST_C_FUNC __attribute__((const))
+#	undef PURE_C_FUNC
+#	define PURE_C_FUNC __attribute__((pure))
+#	undef ALL_PTR_NONNULL
+#	define ALL_PTR_NONNULL __attribute__((nonnull))
+#	undef PTR_NONNULL
+#	define PTR_NONNULL(A) __attribute__((nonnull A))
+#	undef PTR_RESTRICT
+#	define PTR_RESTRICT __restrict__
+#elif defined(_MSC_VER)
+#	undef NO_RETURN
+#	define NO_RETURN __declspec(noreturn)
 #endif
 
-#ifdef __cpp_attributes
-#undef MS_NO_RETURN
-#define MS_NO_RETURN [[noreturn]]
-#else
-#ifdef __GNUC__
-#undef NO_RETURN
-#define NO_RETURN __attribute__ ((noreturn))
+#ifdef __cplusplus
+#	undef NO_RETURN
+#	define NO_RETURN [[noreturn]]
 #endif
-#ifdef _MSC_VER
-#undef MS_NO_RETURN
-#define MS_NO_RETURN __declspec(noreturn)
-#endif
-#endif
-
-/* other compiler blocks */
 
 #if 0
 /* #ifdef __cplusplus */

--- a/Zaimoni.STL/Logging.h
+++ b/Zaimoni.STL/Logging.h
@@ -38,14 +38,14 @@
  *
  * \param B C string containing fatal error message
  */
-EXTERN_C MS_NO_RETURN void _fatal(const char* const B) NO_RETURN;
+EXTERN_C NO_RETURN void _fatal(const char* const B);
 
 /*!
  * reports error, then calls exit(exit_code).
  *
  * \param B C string containing fatal error message
  */
-EXTERN_C MS_NO_RETURN void _fatal_code(const char* const B,int exit_code) NO_RETURN;
+EXTERN_C NO_RETURN void _fatal_code(const char* const B,int exit_code);
 
 EXTERN_C void _inform(const char* const B, size_t len);		/* Windows GUI crippled (assumes len := strlen() */
 EXTERN_C void _inc_inform(const char* const B, size_t len);	/* only C stdio */
@@ -60,11 +60,9 @@ EXTERN_C void _log(const char* const B, size_t len);		/* Windows GUI crippled (a
 
 /* overloadable adapters for C++ and debug-mode code */
 /* all-uppercased because we may use macro wrappers on these */
-MS_NO_RETURN void FATAL(const char* const B) NO_RETURN;
-inline void FATAL(const char* const B) {_fatal(B);}
+[[noreturn]] inline void FATAL(const char* const B) {_fatal(B);}
 
-MS_NO_RETURN void FATAL_CODE(const char* const B,int exit_code) NO_RETURN;
-inline void FATAL_CODE(const char* const B,int exit_code) {_fatal_code(B,exit_code);}
+[[noreturn]] inline void FATAL_CODE(const char* const B,int exit_code) {_fatal_code(B,exit_code);}
 
 /* SEVERE_WARNING, WARNING, INFORM, and LOG are distinct in behavior only for the custom console */
 inline void INC_INFORM(const char* const B) {_inc_inform(B,strlen(B));}


### PR DESCRIPTION
- merged MS_NO_RETURN & NO_RETURN macros
- always use [[noreturn]] for c++ code instead

Diffs messed up again because of trailing white space removal / new line encoding changes.  Very little actual change
other than MS_NO_RETURN renamed to NO_RETURN and the old NO_RETURN was removed since having it as a trailing attribute caused a compile error for GCC.
