### PR TITLE
generic Clock implementation for Linux

### DIFF
--- a/Zaimoni.STL/OS/clock.cpp
+++ b/Zaimoni.STL/OS/clock.cpp
@@ -1,0 +1,16 @@
+#include "clock.hpp"
+#include <chrono>
+
+namespace zaimoni {
+
+const unsigned int Clock::scale = 1000; // how many units per second
+
+unsigned long Clock::n_seconds()
+{
+	using clock = std::chrono::steady_clock;
+	static clock::time_point startTime = clock::now();
+
+	return std::chrono::duration_cast<std::chrono::milliseconds>(clock::now() - startTime).count();
+}
+
+}


### PR DESCRIPTION
Could be used to replace the Windows version as well but probably not as efficient
